### PR TITLE
Change git add command if Pad-Name starts with "-"

### DIFF
--- a/recentpads.php
+++ b/recentpads.php
@@ -192,7 +192,7 @@ function fetch_recent_pads($url, $email, $password, $check_public, $filter_time)
 			fwrite($file, $response->data);
 			fclose($file);
 
-			exec("git add \"".$filename."\"");
+			exec("git add -- \"".$filename."\"");
 		}
 		else{
 			echo("ignored " . $filename . "\n");


### PR DESCRIPTION
If the Pad-Name starts with "-" git add will use the pad-name as parameter. Add -- to fix this.